### PR TITLE
fix: 修复 Save to Wiki 潜在的数据覆盖和内容重复问题

### DIFF
--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -286,21 +286,30 @@ function SaveToWikiButton({ content, visible }: { content: string; visible: bool
         let existingFrontmatter: Record<string, string> = {}
         try {
           existingContent = await readFile(filePath)
-          const fmMatch = existingContent.match(/^---\n([\s\S]*?)\n---\n/)
+          // 兼容 Windows \r\n 和 Unix \n 换行
+          const fmMatch = existingContent.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/)
           if (fmMatch) {
             fmMatch[1].split("\n").forEach((line) => {
               const m = line.match(/^([^:]+):\s*(.*)$/)
               if (m) existingFrontmatter[m[1].trim()] = m[2].trim().replace(/^["']|["']$/g, "")
             })
           }
-        } catch {
-          // File doesn't exist yet
+        } catch (err: any) {
+          // 只有明确"文件不存在"才继续，其他错误中止保存
+          const isNotFound = err?.message?.toLowerCase().includes("not found") 
+            || err?.code === "NotFound"
+            || String(err).toLowerCase().includes("not found")
+          if (!isNotFound) {
+            console.error("读取文件失败，中止保存:", err)
+            throw new Error(`读取文件失败: ${err?.message || String(err)}`)
+          }
+          // 文件确实不存在，正常继续
         }
 
         let finalContent: string
         if (existingContent) {
           // Append new body to existing content, update updated date
-          const existingBody = existingContent.replace(/^---\n[\s\S]*?\n---\n/, "")
+          const existingBody = existingContent.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "")
           const mergedFrontmatter = [
             "---",
             `type: ${existingFrontmatter.type || (subDir === "queries" ? "query" : subDir)}`,


### PR DESCRIPTION
## 修复内容

1. **修复静默 catch 导致的数据覆盖安全隐患**
   - 原逻辑：任何读取失败都被当作"文件不存在"处理，直接用新内容覆盖
   - 新逻辑：只有明确"文件不存在"错误才继续新建，其他错误抛出提示用户，防止数据丢失

2. **修复 Windows \r\n 换行导致的内容重复**
   - 原正则只匹配 `\n`，Windows 下 `\r\n` 换行导致 frontmatter 匹配失败
   - 匹配失败会导致 frontmatter 变成正文的一部分，内容重复
   - 现已兼容 `\r\n` 和 `\n` 两种换行格式

## 受影响平台
- Bug 1（覆盖）: 所有平台
- Bug 2（内容重复）: Windows 特有