### PR TITLE
feat: add three-tier retrieval CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 这个仓库现在的主定位不是单纯桌面应用，而是围绕 live 知识库运行的一套自动化 CLI：
 
-- 多源 RAG 问答：`wiki / raw / graph / facts / brain / stock_daily_sql`
+- 三档多源检索问答：`search / smart-search / ask`，覆盖 `wiki / raw / graph / facts / brain / stock_daily_sql`
 - App-grade 知识摄入：`api-run -> finalize -> apply --write`
 - 盘前预测与盘后验证：`daily-loop`
 - 公司深度研究底稿：`company-research --deep`
@@ -37,7 +37,7 @@ The current `main` branch is optimized for CLI automation and agent-assisted wik
 
 - [CLI 外部接入与使用指南](docs/CLI外部接入与使用指南.md)：给 OpenClaw、龙虾、Shell/Python/Node 调度器和其它非 Codex 软件看的完整接入说明，包含从 0 新建 wiki 化知识库和接入已有 wiki 化知识库两条路径。
 - [交易复盘 Schema 参考模板](docs/交易复盘Schema参考模板.md)：从真实交易复盘 wiki 抽象出的 `schema.md` 示例，适合从 0 建库、改造已有 wiki 或给外部 Agent 定义写入边界。
-- [多源检索 RAG 完整流程](docs/多源检索RAG完整流程.md)：解释 `ask` 如何融合 wiki/raw/graph/facts/brain/SQL。
+- [多源检索 RAG 完整流程](docs/多源检索RAG完整流程.md)：解释 `search / smart-search / ask` 如何融合 wiki/raw/graph/facts/brain/SQL。
 - [Temporal Facts v1](docs/temporal-facts-v1.md)：解释时序事实账本、predicate、状态和人工审计流程。
 
 ## Directory Boundaries
@@ -79,7 +79,27 @@ npm test -- --run
 
 ## 常用命令
 
-### 多源问答
+### 三档检索
+
+不需要最终答案，只想看人能读的证据列表：
+
+```sh
+npm run codex:ingest -- search \
+  --query "AI服务器电源 最近一周" \
+  --project /path/to/your/trading-review-wiki-project \
+  --preset auto
+```
+
+复杂问题先让模型做检索规划和证据重排，但仍不生成最终结论：
+
+```sh
+npm run codex:ingest -- smart-search \
+  --query "AI服务器PCB 上游材料扩散到哪些分支？哪些证据还只是叙事？" \
+  --project /path/to/your/trading-review-wiki-project \
+  --provider codex
+```
+
+需要面向人的完整回答时，再用 `ask`：
 
 ```sh
 npm run codex:ingest -- ask \
@@ -89,6 +109,16 @@ npm run codex:ingest -- ask \
   --show-context \
   --show-sources
 ```
+
+三档区别：
+
+| 命令 | 模型介入 | 输出 | 适合场景 |
+|---|---|---|---|
+| `search` | 不调用模型 | 人可读证据列表或 JSON | 快速查页面、查原文、调试召回 |
+| `smart-search` | 只做检索计划和证据重排，失败时默认退回本地检索 | 证据排序、子查询、缺口 | 复杂问题、产业链扩散、旧结论验证 |
+| `ask` | 检索后生成最终回答 | 带引用的六段式回答 | 用户需要直接看结论和交易含义 |
+
+`--preset auto` 会按问题形状选择 `quick / deep / validate / industry`；也可以显式指定。`smart-search --no-llm-rerank` 会保留模型规划，但跳过证据重排；`--no-fallback` 会在模型规划或重排失败时直接报错。
 
 常用 source：
 
@@ -339,7 +369,9 @@ flowchart TD
 7. `expandAskGraph()` 从 top wiki hits 做有界图谱扩展：默认一跳；产业链/上下游/受益方向类问题自动二跳，也可手动 `--graph-depth 2`。
 8. `facts_jsonl` 和 `brain_memory` 用 JSONL native token filter。
 9. `stock_daily_sql` 用只读 PostgreSQL 查询日线，并生成 Market Validation。
-10. `buildAskPrompt()` 把所有证据编号为 `W/R/G/F/M/S`，要求答案逐条引用。
+10. `search` 到此为止，输出证据列表，不生成结论。
+11. `smart-search` 在本地多源召回前后只让模型做规划和重排，不生成最终回答。
+12. `ask` 调用 `buildAskPrompt()` 把所有证据编号为 `W/R/G/F/M/S`，要求答案逐条引用。
 
 固定回答章节：
 

--- a/docs/CLI外部接入与使用指南.md
+++ b/docs/CLI外部接入与使用指南.md
@@ -7,7 +7,7 @@
 它是围绕本地 Trading Review Wiki 工作区运行的一组命令行能力：
 
 - 把 `raw/**` 原始资料变成可审阅、可回滚的 `wiki/**/*.md` 更新。
-- 对 `wiki / raw / graph / facts / brain / stock_daily_sql` 做多源检索问答。
+- 对 `wiki / raw / graph / facts / brain / stock_daily_sql` 做三档检索问答：`search`、`smart-search`、`ask`。
 - 用 `data/facts/temporal_edges.jsonl` 记录会变化、会失效、会被证伪的时序事实。
 - 用 `data/brain/*.jsonl` 记录纠错、预测、验证、偏好和 guardrail。
 - 生成公司深度研究、盘前问题、盘后验证、训练样本和检索质量评估。
@@ -15,7 +15,7 @@
 核心边界：
 
 - `raw/**` 是原始资料，CLI 不改写。
-- `ask` 永远只读。
+- `search / smart-search / ask` 永远只读。
 - 正式写入 wiki 只通过 `apply --write`。
 - 时序事实只写 `data/facts/temporal_edges.jsonl`。
 - 股票 SQL 只从本机私有配置读取，公开仓库不保存连接信息或密码。
@@ -144,14 +144,40 @@ npm run codex:ingest -- apply \
 建议先做只读接入：
 
 ```sh
+npm run codex:ingest -- search \
+  --query "这个知识库目前有哪些核心主题？" \
+  --project /path/to/existing-wiki \
+  --preset auto
+```
+
+如果需要复杂问题的检索规划和证据重排，但不想让模型直接写结论：
+
+```sh
+npm run codex:ingest -- smart-search \
+  --query "这个知识库里哪些旧计划后来被验证或证伪？" \
+  --project /path/to/existing-wiki \
+  --provider codex \
+  --preset validate
+```
+
+如果需要最终回答，再用：
+
+```sh
 npm run codex:ingest -- ask \
   --query "这个知识库目前有哪些核心主题？" \
   --project /path/to/existing-wiki \
-  --sources wiki,raw,graph \
-  --show-sources
+  --provider codex
 ```
 
-如果能看到 `wikiResults`、`rawResults` 或 `graphExpansions`，说明基本接入成功。
+如果 `search` 能输出 `正式 wiki`、`原始证据` 或 `关联扩展`，说明基本接入成功。要看完整机器上下文时，对 `ask` 加 `--show-context`。
+
+三档区别：
+
+| 命令 | 模型介入 | 输出 | 适合调用方 |
+|---|---|---|---|
+| `search` | 不调用模型 | 证据列表或 JSON | Shell/Python/Node 调度器、快速检索、自动化前置召回 |
+| `smart-search` | 只做检索规划和证据重排，失败时默认退回本地检索 | 子查询、证据排序、缺口 | 复杂问题、主题扩散、验证旧判断 |
+| `ask` | 检索后生成最终回答 | 带引用回答 | 面向用户的问答界面 |
 
 已有库接入前检查：
 
@@ -352,9 +378,28 @@ npm run codex:ingest -- daily-loop \
 
 ## 5. 命令怎么选
 
-### 4.1 只问问题
+### 5.1 只问问题
 
-面向人类阅读：
+只要证据，不要模型写结论：
+
+```sh
+npm run codex:ingest -- search \
+  --query "最近机器人主线是订单兑现还是情绪扩散？" \
+  --project /path/to/wiki-project \
+  --preset auto
+```
+
+复杂问题，需要模型先规划怎么检索、再重排证据：
+
+```sh
+npm run codex:ingest -- smart-search \
+  --query "最近机器人主线是订单兑现还是情绪扩散？哪些证据已经被验证？" \
+  --project /path/to/wiki-project \
+  --provider codex \
+  --preset deep
+```
+
+需要面向人类的完整回答：
 
 ```sh
 npm run codex:ingest -- ask \
@@ -363,17 +408,13 @@ npm run codex:ingest -- ask \
   --provider codex
 ```
 
-面向机器读取检索上下文：
+面向机器解析时，对 `search` 或 `smart-search` 加：
 
 ```sh
-npm run codex:ingest -- ask \
-  --query "最近机器人主线是订单兑现还是情绪扩散？" \
-  --project /path/to/wiki-project \
-  --sources wiki,raw,graph,facts,brain,stock-price \
-  --show-sources
+--output json
 ```
 
-`--show-sources` 输出 JSON，适合外部软件解析：
+如果要调试 `ask` 的源路由，再用 `--show-sources`。它输出 JSON，适合外部软件解析：
 
 - `sourceRouting.selectedSources`
 - `nativeQueries`
@@ -391,7 +432,7 @@ npm run codex:ingest -- ask \
 - `stockDailyResults`
 - `marketValidation`
 
-### 4.2 摄入一份新资料
+### 5.2 摄入一份新资料
 
 推荐流程：
 
@@ -433,7 +474,7 @@ npm run codex:ingest -- apply \
   --write
 ```
 
-### 4.3 维护时序事实
+### 5.3 维护时序事实
 
 摄入 manifest 可以包含 `factWrites`。CLI 只允许写：
 
@@ -479,7 +520,7 @@ npm run codex:ingest -- temporal-facts audit \
 
 这些候选只是人工复核清单，不会自动改写 wiki。
 
-### 4.4 记录长期纠错和偏好
+### 5.4 记录长期纠错和偏好
 
 记录一条纠错：
 
@@ -509,7 +550,7 @@ npm run codex:ingest -- brain resolve \
 
 外部 Agent 可以把用户纠错、盘后复盘结论、失败案例都写入 brain，后续 `ask` 和 `daily-loop` 会把它作为约束和先验，但不会把 brain 当作市场事实本身。
 
-### 4.5 做公司深度研究
+### 5.5 做公司深度研究
 
 ```sh
 npm run codex:ingest -- company-research \
@@ -535,7 +576,7 @@ npm run codex:ingest -- company-research \
 
 它只生成底稿和候选页，不直接写正式 `wiki/**`。
 
-### 4.6 做行情验证
+### 5.6 做行情验证
 
 ```sh
 npm run codex:ingest -- market-validate \
@@ -553,7 +594,7 @@ data/brain/validations.jsonl
 
 如果 SQL 不可用，命令会报告证据不足，不编造行情。
 
-### 4.7 做检索质量评估
+### 5.7 做检索质量评估
 
 ```sh
 npm run codex:ingest -- ask eval \
@@ -570,7 +611,7 @@ npm run codex:ingest -- ask eval \
 
 适合外部软件做回归测试：更新检索策略后，看 recall、source coverage、raw noise 是否变坏。
 
-### 4.8 清理临时报告
+### 5.8 清理临时报告
 
 ```sh
 npm run codex:ingest -- hygiene audit \

--- a/docs/多源检索RAG完整流程.md
+++ b/docs/多源检索RAG完整流程.md
@@ -2,24 +2,35 @@
 
 ## 1. 总览
 
-当前 Trading Review Wiki 的 RAG 主链路是：
+当前 Trading Review Wiki 的检索主链路拆成三档：
 
 ```text
-tw-ask.sh
-  -> npm run codex:ingest -- ask
-  -> askWiki()
+search
+  -> runAskSearch()
   -> buildAskRetrievalContext()
   -> 多源召回 / 融合 / 编号
+  -> 输出人可读证据列表，不调用模型生成答案
+
+smart-search
+  -> runAskSmartSearch()
+  -> LLM 生成检索计划
+  -> runAskSearch() 做本地多查询召回
+  -> LLM 证据重排
+  -> 输出证据排序和缺口，不生成答案
+
+ask
+  -> askWiki()
+  -> buildAskRetrievalContext()
   -> buildAskPrompt()
-  -> Codex 或 OpenAI 生成答案
+  -> Codex 或 OpenAI 生成带引用答案
 ```
 
 这套系统不是单一向量库问答，而是「正式 wiki 为主知识层，raw / graph / facts / brain / SQL / vector 作为补充层」的混合检索。
 
 ```mermaid
 flowchart TD
-  A["用户问题"] --> B["tw-ask.sh 补默认 project/provider"]
-  B --> C["codex-ingest ask"]
+  A["用户问题"] --> B["search / smart-search / ask"]
+  B --> C["preset 路由 quick/deep/validate/industry"]
   C --> D["selectAskSources 源路由"]
   D --> E["wiki/raw 候选召回"]
   D --> F["graph 有界扩展"]
@@ -32,20 +43,42 @@ flowchart TD
   H --> J
   I --> K["Market Validation"]
   K --> J
-  J --> L["buildAskPrompt 带 W/R/G/F/M/S 编号"]
-  L --> M["Codex/OpenAI 生成六段式回答"]
+  J --> L{"入口"}
+  L --> M["search: 证据列表"]
+  L --> N["smart-search: LLM 重排证据"]
+  L --> O["ask: buildAskPrompt"]
+  O --> P["Codex/OpenAI 生成六段式回答"]
 ```
 
 关键入口：
 
-- 技能入口：`/Users/jiegege/.codex/skills/trading-wiki-ask/scripts/tw-ask.sh`
-- CLI 分发：`/Users/jiegege/Downloads/trading-review-wiki-0.10.311/scripts/codex-ingest.mjs`
-- 核心实现：`/Users/jiegege/Downloads/trading-review-wiki-0.10.311/scripts/codex-ingest-lib.mjs`
-- 实时知识库：`/Users/jiegege/Desktop/杰杰杰`
+- CLI 分发：`scripts/codex-ingest.mjs`
+- 核心实现：`scripts/codex-ingest-lib.mjs`
+- 实时知识库：由 `--project /path/to/wiki` 指定
 
-## 2. Source 注册层
+## 2. 三档入口
 
-`ask` 当前支持 6 类 source：
+| 命令 | 模型介入 | 输出 | 默认用途 |
+|---|---|---|---|
+| `search` | 不调用模型 | 人可读证据列表或 JSON | 快速查证据、查原文、看召回 |
+| `smart-search` | 只做检索计划和证据重排，失败时默认退回本地检索 | 子查询、证据排序、证据缺口 | 复杂问题、产业链扩散、旧计划验证 |
+| `ask` | 检索后生成最终回答 | 六段式带引用回答 | 需要直接看结论和交易含义 |
+
+`search` 和 `smart-search` 都是证据检索，不会把片段写成结论；需要最终结论时才进入 `ask`。`smart-search --no-fallback` 可关闭默认降级。
+
+预设：
+
+| preset | 来源组合 | 场景 |
+|---|---|---|
+| `quick` | `wiki,raw,graph` | 页面、实体、精确线索 |
+| `deep` | `wiki,raw,graph,facts,brain` | 综合复盘问题 |
+| `validate` | `wiki,raw,graph,facts,brain,stock-price` | 旧计划验证、证伪、当前状态 |
+| `industry` | `wiki,raw,graph,facts` | 产业链、题材扩散、上下游 |
+| `auto` | 自动选择上面四类 | 默认 |
+
+## 3. Source 注册层
+
+当前支持 6 类 source：
 
 | source | 数据位置 | 含义 | 主要角色 |
 |---|---|---|---|
@@ -71,7 +104,7 @@ flowchart TD
 
 注意：`sourceK` 不是硬上限。规则层如果判断某些源是 required，实际 selected sources 可以超过 `sourceK`。
 
-## 3. Source 路由层
+## 4. Source 路由层
 
 路由函数是：
 
@@ -119,7 +152,7 @@ selectAskSources()
 6. 如果为空，fallback 到 wiki/raw/graph
 ```
 
-## 4. Wiki / Raw 召回层
+## 5. Wiki / Raw 召回层
 
 主召回函数：
 
@@ -140,7 +173,7 @@ searchAskCandidates()
 8. 排序并裁剪 topWiki/topRaw
 ```
 
-### 4.1 Query 分词
+### 5.1 Query 分词
 
 `tokenizeQuery()` 会对中文做二元、三元和单字扩展。例如：
 
@@ -156,7 +189,7 @@ searchAskCandidates()
 
 之后会用 `tokenWeight()` 降权泛词、时间词、单字噪声，保留更像交易证据的词。
 
-### 4.2 Raw 扫描策略
+### 5.2 Raw 扫描策略
 
 raw 目录会快速膨胀，所以 ask 模式不会全量扫到底。
 
@@ -173,7 +206,7 @@ raw 目录会快速膨胀，所以 ask 模式不会全量扫到底。
 - ask：去噪、鲜度、够用优先。
 - ingest：保召回、别漏候选优先。
 
-### 4.3 文件打分
+### 5.3 文件打分
 
 核心函数：
 
@@ -217,7 +250,7 @@ frontmatter freshness 规则：
 | 稳定知识保护 | `策略/模式/错误` 不做重罚，避免老经验因为时间久被误删出上下文 |
 | 调试字段 | `--show-context` 输出 `frontmatterUpdated / frontmatterUpdatedField / staleDays / freshnessScore` |
 
-### 4.4 Wiki 牵引 Raw
+### 5.4 Wiki 牵引 Raw
 
 系统会读取 top wiki 页面的 frontmatter `sources` 字段。
 
@@ -229,7 +262,7 @@ structuredSourceMatch
 
 这一步很关键。它让正式 wiki 页面可以反向牵引原始证据，而不是 raw 和 wiki 各自孤立召回。
 
-## 5. Graph 扩展层
+## 6. Graph 扩展层
 
 图谱函数：
 
@@ -280,7 +313,7 @@ G1, G2, G3...
 
 图谱不是替代正文召回，而是用来找到“同一链条上的相关节点”。
 
-## 6. Facts JSONL 层
+## 7. Facts JSONL 层
 
 函数：
 
@@ -319,7 +352,7 @@ F1, F2, F3...
 - 样本
 - 历史记录
 
-## 7. Brain Memory 层
+## 8. Brain Memory 层
 
 函数：
 
@@ -370,7 +403,7 @@ Brain Memory 只能作为先验、偏好、纠错、卫语句。
 如果 brain 与当前证据冲突，必须写入“分歧/反证”。
 ```
 
-## 8. Stock Daily SQL 层
+## 9. Stock Daily SQL 层
 
 函数：
 
@@ -449,7 +482,7 @@ Market Validation 只是只读市场验证摘要。
 不会自动写回 wiki / facts / brain。
 ```
 
-## 9. Evidence 编号和 Prompt 组装
+## 10. Evidence 编号和 Prompt 组装
 
 核心函数：
 
@@ -510,7 +543,7 @@ buildEvidenceExcerpt()
 | brain | 1800 |
 | SQL | 1800 |
 
-## 10. Answer 生成层
+## 11. Answer 生成层
 
 函数：
 
@@ -546,7 +579,7 @@ provider：
 例如 [W1]、[R2]、[G1]、[F1]、[M1]、[S1]。
 ```
 
-## 11. Vector 检索的位置
+## 12. Vector 检索的位置
 
 当前 CLI `ask` 主链路不是纯向量 RAG。
 
@@ -575,7 +608,7 @@ src/lib/embedding.ts
 
 所以当前架构里，向量是增强层，不是唯一真相源。
 
-## 12. Ask 与 Ingest 的区别
+## 13. Ask 与 Ingest 的区别
 
 虽然 ask 和 ingest 共用部分底层打分函数，但策略不同。
 
@@ -588,30 +621,42 @@ src/lib/embedding.ts
 | 写入 | 只读 | apply --write 才写 |
 | 关注点 | 证据够用、交易含义 | 页面结构、来源归档、schema |
 
-## 13. 调试命令
+## 14. 调试命令
 
-### 13.1 看源路由
+### 14.1 只看本地检索证据
 
 ```sh
-/Users/jiegege/.codex/skills/trading-wiki-ask/scripts/tw-ask.sh \
+npm run codex:ingest -- search \
   --query "你的问题" \
-  --show-sources
+  --project /path/to/your/wiki \
+  --preset auto
 ```
 
-### 13.2 看完整上下文
+### 14.2 复杂问题智能检索
 
 ```sh
-/Users/jiegege/.codex/skills/trading-wiki-ask/scripts/tw-ask.sh \
+npm run codex:ingest -- smart-search \
+  --query "产业链扩散或旧计划验证问题" \
+  --project /path/to/your/wiki \
+  --provider codex
+```
+
+### 14.3 看完整 ask 上下文
+
+```sh
+npm run codex:ingest -- ask \
   --query "你的问题" \
+  --project /path/to/your/wiki \
   --sources wiki,raw,graph,brain \
   --show-context
 ```
 
-### 13.3 强制 wiki/raw/graph
+### 14.4 强制 wiki/raw/graph
 
 ```sh
-/Users/jiegege/.codex/skills/trading-wiki-ask/scripts/tw-ask.sh \
+npm run codex:ingest -- ask \
   --query "最近一周机器人产业链有哪些变化" \
+  --project /path/to/your/wiki \
   --sources wiki,raw,graph \
   --top-wiki 16 \
   --top-raw 16 \
@@ -620,34 +665,37 @@ src/lib/embedding.ts
   --show-context
 ```
 
-### 13.4 加 brain memory
+### 14.5 加 brain memory
 
 ```sh
-/Users/jiegege/.codex/skills/trading-wiki-ask/scripts/tw-ask.sh \
+npm run codex:ingest -- ask \
   --query "最近我在高开接盘上犯过什么错误" \
+  --project /path/to/your/wiki \
   --sources wiki,raw,graph,brain \
   --show-context
 ```
 
-### 13.5 股价 / 量价验证
+### 14.6 股价 / 量价验证
 
 ```sh
-/Users/jiegege/.codex/skills/trading-wiki-ask/scripts/tw-ask.sh \
+npm run codex:ingest -- ask \
   --query "绿的谐波最近20个交易日涨跌幅、成交额和量能变化" \
+  --project /path/to/your/wiki \
   --sources wiki,raw,graph,stock-price \
   --show-context
 ```
 
-### 13.6 只查 SQL
+### 14.7 只查 SQL
 
 ```sh
-/Users/jiegege/.codex/skills/trading-wiki-ask/scripts/tw-ask.sh \
+npm run codex:ingest -- ask \
   --query "688017 最近20个交易日日线和成交额" \
+  --project /path/to/your/wiki \
   --sources stock-price \
   --show-context
 ```
 
-## 14. 当前系统的核心优点
+## 15. 当前系统的核心优点
 
 | 优点 | 解释 |
 |---|---|
@@ -660,7 +708,7 @@ src/lib/embedding.ts
 | 只读安全 | ask 不写 wiki/raw/brain |
 | 可诊断 | `--show-context` 和 `--show-sources` 能看到每一步证据 |
 
-## 15. 当前系统的风险点
+## 16. 当前系统的风险点
 
 | 风险 | 表现 | 处理方式 |
 |---|---|---|
@@ -671,7 +719,7 @@ src/lib/embedding.ts
 | SQL ticker 解析失败 | 股票名/代码无法映射 | query 中明确代码 |
 | vector stale | LanceDB 不同步时语义结果缺失 | 不把向量缺失当知识缺失 |
 
-## 16. 一句话定义
+## 17. 一句话定义
 
 这套 RAG 是：
 

--- a/scripts/codex-ingest-lib.mjs
+++ b/scripts/codex-ingest-lib.mjs
@@ -142,6 +142,103 @@ export const RETRIEVAL_MODES = Object.freeze({
   ASK: "ask",
   INGEST: "ingest",
 })
+export const ASK_SEARCH_PRESETS = Object.freeze({
+  quick: Object.freeze({
+    sources: "wiki,raw,graph",
+    topWiki: 12,
+    topRaw: 12,
+    graphNeighbors: 8,
+    graphDepth: "auto",
+    sourceK: 3,
+    rawScanLimit: 320,
+  }),
+  deep: Object.freeze({
+    sources: "wiki,raw,graph,facts,brain",
+    topWiki: 18,
+    topRaw: 24,
+    graphNeighbors: 12,
+    graphDepth: "auto",
+    topFacts: 12,
+    topBrain: 12,
+    sourceK: 5,
+    rawScanLimit: 1200,
+  }),
+  validate: Object.freeze({
+    sources: "wiki,raw,graph,facts,brain,stock-price",
+    topWiki: 20,
+    topRaw: 30,
+    graphNeighbors: 12,
+    graphDepth: "auto",
+    topFacts: 16,
+    topBrain: 12,
+    sourceK: 6,
+    sqlLimit: 300,
+    rawScanLimit: 1600,
+    includeInvalidated: true,
+  }),
+  industry: Object.freeze({
+    sources: "wiki,raw,graph,facts",
+    topWiki: 18,
+    topRaw: 30,
+    graphNeighbors: 16,
+    graphDepth: "2",
+    topFacts: 12,
+    sourceK: 4,
+    rawScanLimit: 1600,
+  }),
+})
+const ASK_SEARCH_PRESET_NAMES = Object.keys(ASK_SEARCH_PRESETS)
+const ASK_SEARCH_VALIDATE_HINTS = [
+  "验证",
+  "证伪",
+  "失效",
+  "过期",
+  "有效性",
+  "旧计划",
+  "前一交易日",
+  "下一交易日",
+  "codex计划",
+  "交易计划",
+  "review-queue",
+  "pending",
+  "invalidated",
+  "expired",
+  "validate",
+  "falsify",
+]
+const ASK_SEARCH_INDUSTRY_HINTS = [
+  "产业",
+  "产业链",
+  "题材",
+  "上游",
+  "下游",
+  "扩散",
+  "催化",
+  "供应链",
+  "分支",
+  "行业",
+  "主题",
+  "链条",
+]
+const ASK_SEARCH_QUICK_HINTS = ["页面", "在哪", "在哪里", "找", "查", "股票", "概念"]
+const ASK_SEARCH_SOURCE_ALIASES = new Map(
+  Object.entries({
+    wiki: "wiki",
+    wiki_pages: "wiki",
+    raw: "raw",
+    raw_text: "raw",
+    graph: "graph",
+    wiki_graph: "graph",
+    facts: "facts",
+    facts_jsonl: "facts",
+    brain: "brain",
+    brain_memory: "brain",
+    stock: "stock-price",
+    sql: "stock-price",
+    "stock-price": "stock-price",
+    stock_daily_sql: "stock-price",
+  }),
+)
 const ASK_SOURCE_ALIASES = new Map(
   Object.entries({
     auto: "auto",
@@ -7548,6 +7645,485 @@ export async function buildAskRetrievalContext(options = {}) {
     marketValidation,
   }
   return { ...context, prompt: buildAskPrompt(context) }
+}
+
+export function routeAskSearchPreset(query) {
+  const text = String(query ?? "").trim().toLowerCase()
+  if (ASK_SEARCH_VALIDATE_HINTS.some((hint) => text.includes(hint.toLowerCase()))) {
+    return { preset: "validate", reason: "validation/current-status keywords" }
+  }
+  if (ASK_SEARCH_INDUSTRY_HINTS.some((hint) => text.includes(hint.toLowerCase()))) {
+    return { preset: "industry", reason: "industry/theme-spread keywords" }
+  }
+  const compact = text.replace(/\s+/g, "")
+  if (compact.length <= 18 || ASK_SEARCH_QUICK_HINTS.some((hint) => text.includes(hint.toLowerCase()))) {
+    return { preset: "quick", reason: "short entity/page lookup" }
+  }
+  return { preset: "deep", reason: "default complex-review route" }
+}
+
+function normalizeAskSearchPresetName(value, query) {
+  const raw = String(value ?? "auto").trim()
+  if (!raw || raw === "auto") return routeAskSearchPreset(query)
+  if (!ASK_SEARCH_PRESET_NAMES.includes(raw)) throw new Error(`Unknown search preset: ${raw}`)
+  return { preset: raw, reason: "explicit preset" }
+}
+
+function resolveAskSearchOptions(options = {}) {
+  const query = String(options.query ?? "").trim()
+  if (!query) throw new Error("Missing search query")
+  const routed = normalizeAskSearchPresetName(options.preset, query)
+  const preset = ASK_SEARCH_PRESETS[routed.preset]
+  const resolved = {
+    ...options,
+    ...preset,
+    query,
+    projectPath: options.projectPath,
+    preset: routed.preset,
+    sources: options.sources && String(options.sources).trim() && String(options.sources).trim() !== "auto"
+      ? options.sources
+      : preset.sources,
+    topWiki: options.topWiki ?? preset.topWiki,
+    topRaw: options.topRaw ?? preset.topRaw,
+    graphNeighbors: options.graphNeighbors ?? preset.graphNeighbors,
+    graphDepth: options.graphDepth ?? preset.graphDepth,
+    topFacts: options.topFacts ?? preset.topFacts,
+    topBrain: options.topBrain ?? preset.topBrain,
+    sourceK: options.sourceK ?? preset.sourceK,
+    sqlLimit: options.sqlLimit ?? preset.sqlLimit,
+    rawScanLimit: options.rawScanLimit ?? preset.rawScanLimit,
+    maxRawBytes: options.maxRawBytes ?? preset.maxRawBytes,
+    includeInvalidated: Boolean(options.includeInvalidated ?? preset.includeInvalidated),
+  }
+  return { presetName: routed.preset, routeReason: routed.reason, options: resolved }
+}
+
+function compactAskEvidenceItem(item, maxChars = 520) {
+  return {
+    ref: item.ref,
+    path: item.path,
+    title: item.title,
+    score: item.score,
+    type: item.type,
+    sourceId: item.sourceId,
+    nativeQuery: item.nativeQuery,
+    hop: item.hop,
+    pathTrace: item.pathTrace,
+    reasons: item.reasons,
+    temporalStatus: item.temporalStatus,
+    statusReason: item.statusReason,
+    frontmatterUpdated: item.frontmatterUpdated,
+    staleDays: item.staleDays,
+    freshnessScore: item.freshnessScore,
+    snippet: String(item.excerpt || item.snippet || "").slice(0, maxChars),
+  }
+}
+
+export function compactAskRetrievalContext(context, options = {}) {
+  const maxChars = parsePositiveInteger(options.maxSnippetChars, 520)
+  return {
+    query: context.query,
+    projectPath: context.projectPath,
+    generatedAt: context.generatedAt,
+    retrievalMode: context.retrievalMode,
+    tokens: context.tokens,
+    counts: context.counts,
+    sourceRouting: {
+      mode: context.sourceRouting.route.mode,
+      sourceK: context.sourceRouting.route.sourceK,
+      selectedSources: context.sourceRouting.selectedSources.map(({ id, label, kind, nativeLanguage, available, ruleScore, routeReason, unavailableReason }) => ({
+        id,
+        label,
+        kind,
+        nativeLanguage,
+        available,
+        ruleScore,
+        routeReason,
+        unavailableReason,
+      })),
+      warnings: context.sourceRouting.route.warnings,
+    },
+    nativeQueries: context.nativeQueries,
+    retrievalWarnings: context.retrievalWarnings,
+    marketValidation: context.marketValidation,
+    stockDaily: {
+      status: context.stockDaily.status,
+      intent: context.stockDaily.intent,
+      warning: context.stockDaily.warning,
+    },
+    results: {
+      navigation: context.navigation.map((item) => compactAskEvidenceItem(item, maxChars)),
+      wiki: context.wikiResults.map((item) => compactAskEvidenceItem(item, maxChars)),
+      raw: context.rawResults.map((item) => compactAskEvidenceItem(item, maxChars)),
+      graph: context.graphExpansions.map((item) => compactAskEvidenceItem(item, maxChars)),
+      facts: context.factsResults.map((item) => compactAskEvidenceItem(item, maxChars)),
+      invalidatedFacts: context.invalidatedFactsResults.map((item) => compactAskEvidenceItem(item, maxChars)),
+      brain: context.brainResults.map((item) => compactAskEvidenceItem(item, maxChars)),
+      stockDaily: context.stockDailyResults.map((item) => compactAskEvidenceItem(item, maxChars)),
+    },
+  }
+}
+
+export async function runAskSearch(options = {}) {
+  const resolved = resolveAskSearchOptions(options)
+  const context = await buildAskRetrievalContext({
+    ...resolved.options,
+    provider: options.provider ?? "codex",
+  })
+  return {
+    backend: "search",
+    tier: "tier1",
+    preset: resolved.presetName,
+    routeReason: resolved.routeReason,
+    modelCalls: {
+      planner: false,
+      sourceRouter: false,
+      reranker: false,
+      answer: false,
+    },
+    ...compactAskRetrievalContext(context, options),
+  }
+}
+
+function normalizeAskSearchSources(value, fallback) {
+  const rawItems = Array.isArray(value)
+    ? value
+    : String(value ?? "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean)
+  const out = []
+  for (const item of rawItems) {
+    const mapped = ASK_SEARCH_SOURCE_ALIASES.get(String(item).trim()) ?? null
+    if (mapped && !out.includes(mapped)) out.push(mapped)
+  }
+  return out.length > 0 ? out.join(",") : fallback
+}
+
+function normalizeSmartSearchPlan(rawPlan, fallbackQuery, fallbackSources) {
+  const plan = rawPlan && typeof rawPlan === "object" ? { ...rawPlan } : {}
+  const queries = Array.isArray(plan.queries) ? plan.queries : []
+  const normalizedQueries = queries
+    .slice(0, 4)
+    .map((item) => {
+      if (typeof item === "string") return { query: item.trim(), reason: "LLM query expansion" }
+      return {
+        query: String(item?.query ?? "").trim(),
+        reason: String(item?.reason ?? "LLM query expansion").trim(),
+      }
+    })
+    .filter((item) => item.query)
+  if (normalizedQueries.length === 0) normalizedQueries.push({ query: fallbackQuery, reason: "fallback original query" })
+  return {
+    intent: String(plan.intent ?? "deep"),
+    sources: normalizeAskSearchSources(plan.sources, fallbackSources),
+    queries: normalizedQueries,
+    expandedTerms: Array.isArray(plan.expanded_terms) ? plan.expanded_terms.map(String).filter(Boolean).slice(0, 24) : [],
+    includeInvalidated: Boolean(plan.include_invalidated),
+    rankingRules: Array.isArray(plan.ranking_rules) ? plan.ranking_rules.map(String).filter(Boolean).slice(0, 8) : [],
+    evidenceGapsToWatch: Array.isArray(plan.evidence_gaps_to_watch) ? plan.evidence_gaps_to_watch.map(String).filter(Boolean).slice(0, 8) : [],
+  }
+}
+
+function buildSmartSearchPlanPrompt({ query, presetName, preset }) {
+  return [
+    "# Trading Review Wiki Smart Retrieval Plan",
+    "",
+    `question: ${query}`,
+    `default_preset: ${presetName}`,
+    `default_sources: ${preset.sources}`,
+    "",
+    "Knowledge-base logic:",
+    "- raw/ is immutable evidence, not conclusion.",
+    "- wiki/ is durable human-readable conclusion, but can be stale.",
+    "- data/facts/ is temporal status: active, validated, invalidated, superseded, expired.",
+    "- data/brain/ is operational memory and guardrail, not trade fact evidence.",
+    "- industry research must be translated through tape/fund validation and L1-L4 before trading permission.",
+    "",
+    "Return JSON only with this schema:",
+    "```json",
+    JSON.stringify({
+      intent: "quick|deep|validate|industry|trade-error|audit",
+      sources: ["wiki", "raw", "graph", "facts", "brain", "stock-price"],
+      queries: [{ query: "...", reason: "..." }],
+      expanded_terms: ["..."],
+      include_invalidated: false,
+      ranking_rules: ["..."],
+      evidence_gaps_to_watch: ["..."],
+    }, null, 2),
+    "```",
+    "",
+    "Rules:",
+    "- Create 1 to 4 search queries, not final answers.",
+    "- For validation/current-status questions include facts and brain; include invalidated facts when useful.",
+    "- For industry-chain questions include wiki/raw/graph/facts.",
+    "- For trade mistakes/execution include wiki/raw/graph/facts/brain.",
+    "- Do not invent evidence paths.",
+  ].join("\n")
+}
+
+async function requestAskSearchJson({ stage, prompt, instructions, options, projectPath }) {
+  if (options.requestSmartSearchText) {
+    return parseJsonObjectFromModelText(await options.requestSmartSearchText({ stage, prompt, instructions }))
+  }
+  const provider = options.provider ?? "codex"
+  let text
+  if (provider === "codex") {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "trading-wiki-smart-search-"))
+    const outputPath = path.join(tmpDir, `${stage}.json`)
+    try {
+      text = await requestCodexExecText({
+        stage,
+        prompt,
+        instructions,
+        model: options.model,
+        prepared: { projectPath },
+        outputPath,
+        codexBin: options.codexBin,
+        codexProfile: options.codexProfile,
+        codexProfileV2: options.codexProfileV2,
+        codexTimeoutMs: options.codexTimeoutMs,
+      })
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    }
+  } else if (provider === "openai") {
+    const apiKey = options.apiKey ?? process.env.OPENAI_API_KEY
+    const model = options.model ?? process.env.OPENAI_MODEL
+    if (!apiKey) throw new Error("Missing OpenAI API key. Pass --api-key or set OPENAI_API_KEY, or use --provider codex.")
+    if (!model) throw new Error("Missing model. Pass --model or set OPENAI_MODEL.")
+    text = await requestResponsesText({
+      apiKey,
+      endpoint: options.endpoint,
+      model,
+      prompt,
+      instructions,
+      reasoningEffort: options.reasoningEffort ?? "low",
+    })
+  } else {
+    throw new Error(`Unsupported smart-search provider: ${provider}`)
+  }
+  return parseJsonObjectFromModelText(text)
+}
+
+function mergeAskSearchBucket(searches, bucket, limit = 40) {
+  const best = new Map()
+  for (const search of searches) {
+    for (const item of search.results?.[bucket] ?? []) {
+      const key = item.path || `${bucket}:${item.title}:${item.ref}`
+      const previous = best.get(key)
+      if (!previous || Number(item.score ?? 0) > Number(previous.score ?? 0)) {
+        best.set(key, item)
+      }
+    }
+  }
+  return [...best.values()].sort((a, b) => Number(b.score ?? 0) - Number(a.score ?? 0) || String(a.path ?? "").localeCompare(String(b.path ?? ""))).slice(0, limit)
+}
+
+function flattenSmartSearchEvidence(payload, limit = 80) {
+  const out = []
+  for (const [bucket, items] of Object.entries(payload.results ?? {})) {
+    for (const [index, item] of items.entries()) {
+      out.push({
+        id: `${bucket}:${index + 1}`,
+        bucket,
+        path: item.path,
+        title: item.title,
+        score: item.score,
+        snippet: item.snippet,
+      })
+      if (out.length >= limit) return out
+    }
+  }
+  return out
+}
+
+function mergeAskSearchPayloads({ query, projectPath, presetName, routeReason, plan, searches }) {
+  const results = {
+    navigation: mergeAskSearchBucket(searches, "navigation"),
+    wiki: mergeAskSearchBucket(searches, "wiki"),
+    raw: mergeAskSearchBucket(searches, "raw"),
+    graph: mergeAskSearchBucket(searches, "graph"),
+    facts: mergeAskSearchBucket(searches, "facts"),
+    invalidatedFacts: mergeAskSearchBucket(searches, "invalidatedFacts"),
+    brain: mergeAskSearchBucket(searches, "brain"),
+    stockDaily: mergeAskSearchBucket(searches, "stockDaily"),
+  }
+  const counts = {
+    wikiMatches: results.wiki.length,
+    rawMatches: results.raw.length,
+    graphMatches: results.graph.length,
+    factsMatches: results.facts.length,
+    invalidatedFactsMatches: results.invalidatedFacts.length,
+    brainMatches: results.brain.length,
+    sqlRows: results.stockDaily.length,
+  }
+  return {
+    backend: "smart-search",
+    tier: "tier2",
+    preset: presetName,
+    routeReason,
+    query,
+    projectPath,
+    generatedAt: nowLocalTimestamp(),
+    modelCalls: {
+      planner: true,
+      sourceRouter: false,
+      reranker: false,
+      answer: false,
+    },
+    plan,
+    counts,
+    searches: searches.map((item) => ({
+      query: item.query,
+      preset: item.preset,
+      counts: item.counts,
+      sourceRouting: item.sourceRouting,
+    })),
+    results,
+    rankedEvidence: [],
+    evidenceGaps: plan.evidenceGapsToWatch,
+    warnings: [],
+  }
+}
+
+function buildSmartSearchRerankPrompt(payload) {
+  return [
+    "# Trading Review Wiki Evidence Rerank",
+    "",
+    `question: ${payload.query}`,
+    "",
+    "Retrieval plan:",
+    "```json",
+    JSON.stringify(payload.plan, null, 2),
+    "```",
+    "",
+    "Evidence candidates:",
+    "```json",
+    JSON.stringify(flattenSmartSearchEvidence(payload), null, 2),
+    "```",
+    "",
+    "Return JSON only:",
+    "```json",
+    JSON.stringify({
+      ranked_ids: [{ id: "wiki:1", why: "..." }],
+      evidence_gaps: ["..."],
+      warnings: ["..."],
+    }, null, 2),
+    "```",
+    "",
+    "Rules:",
+    "- Rank evidence, do not answer the trading question.",
+    "- Prefer formal wiki for durable conclusions, raw for recent proof, facts for current status, brain for guardrails.",
+    "- Mark stale/invalidated/insufficient evidence as warnings or gaps.",
+  ].join("\n")
+}
+
+export async function runAskSmartSearch(options = {}) {
+  const resolved = resolveAskSearchOptions(options)
+  const projectPath = normalizePath(options.projectPath ?? DEFAULT_PROJECT_PATH)
+  let planRaw
+  try {
+    planRaw = await requestAskSearchJson({
+      stage: "smart-search-plan",
+      projectPath,
+      options,
+      instructions: "You are a retrieval planner for a local trading review knowledge base. Return only JSON.",
+      prompt: buildSmartSearchPlanPrompt({
+        query: resolved.options.query,
+        presetName: resolved.presetName,
+        preset: ASK_SEARCH_PRESETS[resolved.presetName],
+      }),
+    })
+  } catch (err) {
+    if (options.fallback === false) throw err
+    const fallback = await runAskSearch({
+      ...resolved.options,
+      ...options,
+      query: resolved.options.query,
+      preset: resolved.presetName,
+      projectPath,
+    })
+    return {
+      ...fallback,
+      backend: "smart-search-fallback",
+      fallback: {
+        stage: "smart-search-plan",
+        reason: err instanceof Error ? err.message : String(err),
+      },
+      modelCalls: {
+        planner: true,
+        sourceRouter: false,
+        reranker: false,
+        answer: false,
+      },
+      warnings: [
+        `smart-search planner failed; fell back to tier-1 search: ${err instanceof Error ? err.message : String(err)}`,
+        ...(fallback.warnings ?? []),
+      ],
+    }
+  }
+  const plan = normalizeSmartSearchPlan(planRaw, resolved.options.query, resolved.options.sources)
+  const searches = []
+  for (const item of plan.queries) {
+    searches.push(await runAskSearch({
+      ...resolved.options,
+      ...options,
+      query: item.query,
+      preset: resolved.presetName,
+      projectPath,
+      sources: plan.sources,
+      includeInvalidated: Boolean(options.includeInvalidated || plan.includeInvalidated),
+    }))
+  }
+  const payload = mergeAskSearchPayloads({
+    query: resolved.options.query,
+    projectPath,
+    presetName: resolved.presetName,
+    routeReason: resolved.routeReason,
+    plan,
+    searches,
+  })
+  if (options.llmRerank === false) return payload
+
+  let rerankRaw
+  try {
+    rerankRaw = await requestAskSearchJson({
+      stage: "smart-search-rerank",
+      projectPath,
+      options,
+      instructions: "You are an evidence reranker for a local trading review knowledge base. Return only JSON.",
+      prompt: buildSmartSearchRerankPrompt(payload),
+    })
+  } catch (err) {
+    if (options.fallback === false) throw err
+    return {
+      ...payload,
+      modelCalls: { ...payload.modelCalls, reranker: true },
+      fallback: {
+        stage: "smart-search-rerank",
+        reason: err instanceof Error ? err.message : String(err),
+      },
+      warnings: [
+        `smart-search rerank failed; returned merged local retrieval: ${err instanceof Error ? err.message : String(err)}`,
+      ],
+    }
+  }
+  const candidatesById = new Map(flattenSmartSearchEvidence(payload).map((item) => [item.id, item]))
+  const rankedEvidence = []
+  for (const item of Array.isArray(rerankRaw.ranked_ids) ? rerankRaw.ranked_ids : []) {
+    const id = typeof item === "string" ? item : String(item?.id ?? "")
+    const evidence = candidatesById.get(id)
+    if (evidence) rankedEvidence.push({ ...evidence, why: typeof item === "string" ? "" : String(item?.why ?? "") })
+    if (rankedEvidence.length >= parsePositiveInteger(options.topRanked, 12)) break
+  }
+  return {
+    ...payload,
+    modelCalls: { ...payload.modelCalls, reranker: true },
+    rankedEvidence,
+    evidenceGaps: Array.isArray(rerankRaw.evidence_gaps) ? rerankRaw.evidence_gaps.map(String) : payload.evidenceGaps,
+    warnings: Array.isArray(rerankRaw.warnings) ? rerankRaw.warnings.map(String) : [],
+  }
 }
 
 export async function askWiki(options = {}) {

--- a/scripts/codex-ingest-lib.test.mjs
+++ b/scripts/codex-ingest-lib.test.mjs
@@ -28,11 +28,14 @@ import {
   rememberBrainMemory,
   resolveBrainMemory,
   runAskEval,
+  runAskSearch,
+  runAskSmartSearch,
   runCompanyResearch,
   runDailyLoop,
   runHygiene,
   runSelfTraining,
   runTemporalFactsAudit,
+  routeAskSearchPreset,
   searchCandidatePages,
   selectAskSources,
   tokenizeQuery,
@@ -927,6 +930,110 @@ LogicFolding 可能和华为τ定律页面冲突。
     expect(candidates.wikiCandidates.every((item) => item.retrievalMode === "ingest")).toBe(true)
     expect(context.retrievalMode).toBe("ask")
     expect(context.wikiResults.every((item) => item.retrievalMode === "ask")).toBe(true)
+  })
+
+  it("routes search presets by question shape", () => {
+    expect(routeAskSearchPreset("2026-06-12 Codex 交易计划 验证").preset).toBe("validate")
+    expect(routeAskSearchPreset("AI服务器PCB 上游材料 扩散").preset).toBe("industry")
+    expect(routeAskSearchPreset("算电协同").preset).toBe("quick")
+    expect(routeAskSearchPreset("最近一个月AI服务器电源和电力运营商重估之间的证据链有什么变化").preset).toBe("deep")
+  })
+
+  it("runs tier-1 ask search without model calls", async () => {
+    const result = await runAskSearch({
+      projectPath: tmpRoot,
+      query: "AI服务器电源 最近一周",
+      preset: "quick",
+      topWiki: 3,
+      topRaw: 3,
+    })
+
+    expect(result.tier).toBe("tier1")
+    expect(result.backend).toBe("search")
+    expect(result.preset).toBe("quick")
+    expect(result.modelCalls).toEqual({
+      planner: false,
+      sourceRouter: false,
+      reranker: false,
+      answer: false,
+    })
+    expect(result.sourceRouting.mode).toBe("explicit")
+    expect(result.results.wiki.map((item) => item.path)).toContain("wiki/概念/算电协同.md")
+    expect(result.results.raw.map((item) => item.path)).toContain("raw/研报新闻/2026-05-28-AI服务器电源.md")
+  })
+
+  it("runs tier-2 smart search with model planning and rerank but no final answer", async () => {
+    const stages = []
+    const result = await runAskSmartSearch({
+      projectPath: tmpRoot,
+      query: "AI服务器电源 最近一周",
+      preset: "quick",
+      topWiki: 3,
+      topRaw: 3,
+      requestSmartSearchText: async ({ stage }) => {
+        stages.push(stage)
+        if (stage === "smart-search-plan") {
+          return JSON.stringify({
+            intent: "quick",
+            sources: ["wiki", "raw", "graph"],
+            queries: [{ query: "AI服务器电源 最近一周", reason: "original user query" }],
+            expanded_terms: ["算电协同", "数据中心供电"],
+            include_invalidated: false,
+            ranking_rules: ["prefer formal wiki for durable conclusions"],
+            evidence_gaps_to_watch: ["watch current order validation"],
+          })
+        }
+        return JSON.stringify({
+          ranked_ids: [{ id: "wiki:1", why: "core durable concept page" }],
+          evidence_gaps: ["needs latest market validation"],
+          warnings: ["raw evidence may be stale"],
+        })
+      },
+    })
+
+    expect(stages).toEqual(["smart-search-plan", "smart-search-rerank"])
+    expect(result.tier).toBe("tier2")
+    expect(result.backend).toBe("smart-search")
+    expect(result.modelCalls).toEqual({
+      planner: true,
+      sourceRouter: false,
+      reranker: true,
+      answer: false,
+    })
+    expect(result.plan.sources).toBe("wiki,raw,graph")
+    expect(result.rankedEvidence[0]).toMatchObject({
+      id: "wiki:1",
+      path: "wiki/概念/算电协同.md",
+      why: "core durable concept page",
+    })
+    expect(result.evidenceGaps).toContain("needs latest market validation")
+    expect(result.warnings).toContain("raw evidence may be stale")
+  })
+
+  it("falls back to tier-1 retrieval when smart-search planning fails", async () => {
+    const result = await runAskSmartSearch({
+      projectPath: tmpRoot,
+      query: "AI服务器电源 最近一周",
+      preset: "quick",
+      requestSmartSearchText: async () => {
+        throw new Error("planner unavailable")
+      },
+    })
+
+    expect(result.backend).toBe("smart-search-fallback")
+    expect(result.tier).toBe("tier1")
+    expect(result.fallback).toMatchObject({
+      stage: "smart-search-plan",
+      reason: "planner unavailable",
+    })
+    expect(result.modelCalls).toEqual({
+      planner: true,
+      sourceRouter: false,
+      reranker: false,
+      answer: false,
+    })
+    expect(result.results.wiki.map((item) => item.path)).toContain("wiki/概念/算电协同.md")
+    expect(result.warnings[0]).toContain("fell back to tier-1 search")
   })
 
   it("ask retrieval reads frontmatter freshness and decays stale topic pages", async () => {

--- a/scripts/codex-ingest.mjs
+++ b/scripts/codex-ingest.mjs
@@ -13,6 +13,8 @@ import {
   rememberBrainMemory,
   resolveBrainMemory,
   runAskEval,
+  runAskSearch,
+  runAskSmartSearch,
   runCompanyResearch,
   runDailyLoop,
   runHygiene,
@@ -27,6 +29,8 @@ function printHelp() {
   npm run codex:ingest -- api-run --provider codex --source <raw-file> [--project <wiki-root>] [--model <model>] [--page-concurrency <n>] [--max-plan-items <n>]
   npm run codex:ingest -- finalize --report <codex-ingest-report-dir> [--provider codex]
   npm run codex:ingest -- apply --manifest <changes.json> [--project <wiki-root>] [--write]
+  npm run codex:ingest -- search --query "..." [--project <wiki-root>] [--preset auto|quick|deep|validate|industry] [--output text|json]
+  npm run codex:ingest -- smart-search --query "..." [--project <wiki-root>] [--preset auto|quick|deep|validate|industry] [--no-llm-rerank] [--no-fallback] [--output text|json]
   npm run codex:ingest -- ask --query "..." [--project <wiki-root>] [--provider codex] [--show-context] [--show-sources] [--include-invalidated]
   npm run codex:ingest -- ask eval [--query "..."] [--expect-paths wiki/概念/xxx.md,raw/研报新闻/xxx.md] [--project <wiki-root>] [--write]
   npm run codex:ingest -- brain remember --type correction|thread|preference|guardrail --text "..." [--project <wiki-root>]
@@ -50,9 +54,10 @@ Notes:
   --provider codex uses the local Codex CLI login instead of OPENAI_API_KEY.
   --page-concurrency controls parallel FILE-block generation; defaults to 1.
   --max-plan-items, --max-create-pages, and --max-update-pages record soft plan-budget warnings in plan-budget.json; they do not stop normal ingest.
+  retrieval tiers: search is local multi-source evidence retrieval; smart-search uses the LLM only for retrieval planning/evidence reranking and falls back to local search unless --no-fallback is set; ask generates a final cited answer.
   ask is read-only. Use --show-context to print retrieval hits; use --show-sources to print source routing/native query summaries.
   ask eval is read-only by default and reports retrieval recall/relevance/source coverage/raw-noise/structure scores; --write stores only .llm-wiki/eval/*.json.
-  ask source controls: --source-k 3 --sources auto|wiki,raw,graph,facts,brain,stock-price --graph-depth auto|1|2 --top-brain 8 --sql-limit 200 --include-invalidated.
+  ask source controls: --source-k 3 --sources auto|wiki,raw,graph,facts,brain,stock-price --graph-depth auto|1|2 --top-brain 8 --sql-limit 200 --raw-scan-limit 320 --max-raw-bytes <n> --include-invalidated.
   daily-loop controls: --question-count <n> --lookback-days 30 --max-stocks-per-question 8 --max-existing-validations <n> --validation-windows 1,3,5,10,20 --market-validate auto|off|tencent|eastmoney --validate-pending-only.
   daily-loop questions are planned by the provider LLM first; rules/templates are only fallback.
   brain/market/self-train commands write only data/brain or .llm-wiki/exports when explicitly invoked; ask remains read-only.
@@ -74,7 +79,7 @@ function parseArgs(argv) {
       continue
     }
     const key = token.slice(2)
-    if (["write", "no-report", "allow-source-change", "help", "show-context", "show-sources", "include-invalidated", "validate-pending-only", "deep"].includes(key)) {
+    if (["write", "no-report", "allow-source-change", "help", "show-context", "show-sources", "include-invalidated", "validate-pending-only", "deep", "no-llm-rerank", "no-fallback"].includes(key)) {
       args[key] = true
       continue
     }
@@ -91,6 +96,114 @@ function parseArgs(argv) {
 function requireArg(args, name) {
   if (!args[name]) throw new Error(`Missing required --${name}`)
   return args[name]
+}
+
+function oneLine(value, limit = 220) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim()
+  return text.length <= limit ? text : `${text.slice(0, limit - 1).trimEnd()}...`
+}
+
+function renderHits(items, title, limit = 5) {
+  if (!items?.length) return []
+  const lines = ["", title]
+  for (const [index, item] of items.slice(0, limit).entries()) {
+    const score = Number.isFinite(Number(item.score)) ? ` | score ${Math.round(Number(item.score) * 1000) / 1000}` : ""
+    lines.push(`${index + 1}. ${item.title ?? item.path ?? item.id}${score}`)
+    if (item.path) lines.push(`   ${item.path}`)
+    if (item.snippet) lines.push(`   ${oneLine(item.snippet)}`)
+    if (item.why) lines.push(`   why: ${oneLine(item.why, 180)}`)
+    if (item.reasons?.length) lines.push(`   reason: ${oneLine(item.reasons.slice(0, 2).join("; "), 180)}`)
+  }
+  return lines
+}
+
+function renderAskSearchText(result) {
+  const calls = result.modelCalls ?? {}
+  const lines = [
+    `查询：${result.query}`,
+    `检索：${result.backend} / ${result.preset}`,
+    `模型：计划 ${calls.planner ? "是" : "否"}，路由 ${calls.sourceRouter ? "是" : "否"}，重排 ${calls.reranker ? "是" : "否"}，回答 ${calls.answer ? "是" : "否"}`,
+  ]
+  if (result.routeReason) lines.push(`路由原因：${result.routeReason}`)
+  if (result.plan) {
+    lines.push(`意图：${result.plan.intent}`)
+    lines.push(`来源：${result.plan.sources}`)
+    if (result.plan.queries?.length) {
+      lines.push("子查询：")
+      for (const item of result.plan.queries.slice(0, 5)) lines.push(`- ${item.query}（${oneLine(item.reason, 120)}）`)
+    }
+    if (result.plan.expandedTerms?.length) lines.push(`扩展词：${result.plan.expandedTerms.slice(0, 18).join(" / ")}`)
+    if (result.plan.rankingRules?.length) lines.push(`排序规则：${result.plan.rankingRules.slice(0, 4).map((item) => oneLine(item, 80)).join("；")}`)
+  }
+  const counts = result.counts ?? {}
+  lines.push(`命中：wiki ${counts.wikiMatches ?? 0}，raw ${counts.rawMatches ?? 0}，graph ${counts.graphMatches ?? 0}，facts ${counts.factsMatches ?? 0}，brain ${counts.brainMatches ?? 0}，SQL ${counts.sqlRows ?? 0}`)
+  if (result.sourceRouting?.selectedSources?.length) {
+    const usable = result.sourceRouting.selectedSources.filter((item) => item.available).map((item) => item.id)
+    if (usable.length) lines.push(`来源：${usable.join(" / ")}`)
+  }
+  if (result.rankedEvidence?.length) {
+    lines.push(...renderHits(result.rankedEvidence, "证据排序", 10))
+  } else {
+    const sections = [
+      ["wiki", "正式 wiki"],
+      ["raw", "原始证据"],
+      ["graph", "关联扩展"],
+      ["facts", "时序事实"],
+      ["invalidatedFacts", "失效事实"],
+      ["brain", "运行记忆"],
+      ["stockDaily", "行情数据"],
+      ["navigation", "导航"],
+    ]
+    for (const [key, title] of sections) lines.push(...renderHits(result.results?.[key] ?? [], title))
+  }
+  if (result.evidenceGaps?.length) {
+    lines.push("", "证据缺口")
+    for (const gap of result.evidenceGaps.slice(0, 8)) lines.push(`- ${oneLine(gap, 180)}`)
+  }
+  if (result.warnings?.length) {
+    lines.push("", "警告")
+    for (const warning of result.warnings.slice(0, 8)) lines.push(`- ${oneLine(warning, 180)}`)
+  }
+  if (result.fallback) {
+    lines.push("", `兜底：${result.fallback.stage} -> ${oneLine(result.fallback.reason, 180)}`)
+  }
+  lines.push("", result.tier === "tier2" ? "下一步：smart-search 只排序证据，不生成结论；需要正式回答时用 ask。" : "下一步：打开上面的路径阅读全文；检索片段只是线索，不等于正式结论。")
+  lines.push("需要机器格式时加：--output json")
+  return `${lines.join("\n").trimEnd()}\n`
+}
+
+function buildAskRetrievalArgs(args) {
+  return {
+    query: requireArg(args, "query"),
+    projectPath: args.project,
+    provider: args.provider ?? "codex",
+    model: args.model,
+    apiKey: args["api-key"],
+    endpoint: args.endpoint,
+    reasoningEffort: args["reasoning-effort"],
+    codexBin: args["codex-bin"],
+    codexProfile: args["codex-profile"],
+    codexProfileV2: args["codex-profile-v2"],
+    codexTimeoutMs: args["codex-timeout-ms"],
+    preset: args.preset,
+    topWiki: args["top-wiki"],
+    topRaw: args["top-raw"],
+    graphNeighbors: args["graph-neighbors"],
+    graphDepth: args["graph-depth"],
+    topFacts: args["top-facts"],
+    topBrain: args["top-brain"],
+    includeInvalidated: Boolean(args["include-invalidated"]),
+    sourceK: args["source-k"],
+    sources: args.sources,
+    sqlLimit: args["sql-limit"],
+    rawScanLimit: args["raw-scan-limit"],
+    maxRawBytes: args["max-raw-bytes"],
+  }
+}
+
+function printSearchResult(result, args) {
+  if (args.output === "json") console.log(JSON.stringify(result, null, 2))
+  else console.log(renderAskSearchText(result).trimEnd())
 }
 
 async function main() {
@@ -406,6 +519,23 @@ async function main() {
     return
   }
 
+  if (command === "search" || command === "retrieve") {
+    const result = await runAskSearch(buildAskRetrievalArgs(args))
+    printSearchResult(result, args)
+    return
+  }
+
+  if (command === "smart-search") {
+    const result = await runAskSmartSearch({
+      ...buildAskRetrievalArgs(args),
+      llmRerank: !args["no-llm-rerank"],
+      fallback: !args["no-fallback"],
+      topRanked: args["top-ranked"],
+    })
+    printSearchResult(result, args)
+    return
+  }
+
   if (command === "ask" || command === "query") {
     if (args._[1] === "eval") {
       const result = await runAskEval({
@@ -449,6 +579,8 @@ async function main() {
       sourceK: args["source-k"],
       sources: args.sources,
       sqlLimit: args["sql-limit"],
+      rawScanLimit: args["raw-scan-limit"],
+      maxRawBytes: args["max-raw-bytes"],
       showContext: Boolean(args["show-context"] || args["show-sources"]),
     })
     if (args["show-context"] || args["show-sources"]) {


### PR DESCRIPTION
新增三档检索能力：

- search：本地多源证据检索，不调用模型
- smart-search：模型只做检索规划和证据重排，失败自动退回本地检索
- ask：基于检索证据生成最终带引用回答

同步更新：

- CLI help
- README 使用说明
- 外部接入文档
- 多源 RAG 流程文档
- 回归测试

验证：

- node --check scripts/codex-ingest.mjs && node --check scripts/codex-ingest-lib.mjs
- npm test -- --run
- npm run build

补充：build 通过，但 Vite 仍保留既有 chunk/dynamic import 警告。